### PR TITLE
Fix payload overflow / status code issues for recursive queries

### DIFF
--- a/answers.go
+++ b/answers.go
@@ -88,7 +88,9 @@ func (answers *Answers) Addresses(clientIp string, fqdn string, cnameParents []d
 	// When resolving CNAMES, check recursive server
 	if len(cnameParents) > 0 {
 		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Debug("Trying recursive servers")
-		msg, err := ResolveTryAll(fqdn, dns.TypeA, answers.Recursers(clientIp))
+		r := new(dns.Msg)
+		r.SetQuestion(fqdn, dns.TypeA)
+		msg, err := ResolveTryAll(r, answers.Recursers(clientIp))
 		if err == nil {
 			return msg.Answer, true
 		}


### PR DESCRIPTION
This PR fixes https://github.com/rancher/rancher/issues/2930 and https://github.com/rancher/rancher/issues/2928
* Make sure payload of recursive reply fits the buffer size, otherwise return truncated
message for UDP
* Don’t overwrite the return code of recursive replies

