### PR TITLE
Search both client and default answers with search

### DIFF
--- a/answers.go
+++ b/answers.go
@@ -58,33 +58,34 @@ func (answers *Answers) SearchSuffixes(clientIp string) []string {
 	return hosts
 }
 
-func (answers *Answers) Addresses(clientIp string, fqdn string, cnameParents []dns.RR, depth int, searches []string) (records []dns.RR, ok bool) {
+func (answers *Answers) Addresses(clientIp string, fqdn string, cnameParents []dns.RR, depth int) (records []dns.RR, ok bool) {
 	fqdn = dns.Fqdn(fqdn)
 
 	log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Trying to resolve addresses")
 
 	// Limit recursing for non-obvious loops
 	if len(cnameParents) >= MAX_DEPTH {
-		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Warn("Followed CNAME too many times ", cnameParents)
+		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Warn("Followed CNAME too many times ", cnameParents)
 		return nil, false
 	}
 
 	// Look for a CNAME entry
-	result, ok := answers.MatchingAny(dns.TypeCNAME, clientIp, fqdn, searches)
+	log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Trying CNAME Records")
+	result, ok := answers.Matching(dns.TypeCNAME, clientIp, fqdn)
 	if ok && len(result) > 0 {
 		cname := result[0].(*dns.CNAME)
-		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Debug("Matched CNAME ", cname.Target)
+		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Matched CNAME ", cname.Target)
 
 		// Stop obvious loops
 		if dns.Fqdn(cname.Target) == fqdn {
-			log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Warn("CNAME is a loop ", cname.Target)
+			log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Warn("CNAME is a loop ", cname.Target)
 			return nil, false
 		}
 
 		// Recurse to find the eventual A for this CNAME
-		children, ok := answers.Addresses(clientIp, dns.Fqdn(cname.Target), append(cnameParents, cname), depth+1, searches)
+		children, ok := answers.Addresses(clientIp, dns.Fqdn(cname.Target), append(cnameParents, cname), depth+1)
 		if ok && len(children) > 0 {
-			log.WithFields(log.Fields{"fqdn": fqdn, "target": cname.Target, "client": clientIp}).Debug("Resolved CNAME ", children)
+			log.WithFields(log.Fields{"fqdn": fqdn, "target": cname.Target, "client": clientIp, "depth": depth}).Debug("Resolved CNAME ", children)
 			records = append(records, cname)
 			records = append(records, children...)
 			return records, true
@@ -92,22 +93,17 @@ func (answers *Answers) Addresses(clientIp string, fqdn string, cnameParents []d
 	}
 
 	// Look for an A entry
-	result, ok = answers.MatchingAny(dns.TypeA, clientIp, fqdn, searches)
+	log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Trying A Records")
+	result, ok = answers.Matching(dns.TypeA, clientIp, fqdn)
 	if ok && len(result) > 0 {
-		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Debug("Matched A ", result)
+		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Matched A ", result)
 		shuffle(&result)
 		return result, true
 	}
 
-	// Try the default section of the config
-	if clientIp != DEFAULT_KEY {
-		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Debug("Trying defaults")
-		return answers.Addresses(DEFAULT_KEY, fqdn, cnameParents, depth+1, searches)
-	}
-
 	// When resolving CNAMES, check recursive server
 	if len(cnameParents) > 0 {
-		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Debug("Trying recursive servers")
+		log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Trying recursive servers")
 		r := new(dns.Msg)
 		r.SetQuestion(fqdn, dns.TypeA)
 		msg, err := ResolveTryAll(r, answers.Recursers(clientIp))
@@ -116,12 +112,40 @@ func (answers *Answers) Addresses(clientIp string, fqdn string, cnameParents []d
 		}
 	}
 
-	log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp}).Debug("Did not match anything")
+	log.WithFields(log.Fields{"fqdn": fqdn, "client": clientIp, "depth": depth}).Debug("Did not match anything")
 	return nil, false
 }
 
-func (answers *Answers) MatchingAny(qtype uint16, clientIp string, label string, searches []string) (records []dns.RR, ok bool) {
-	records, ok = answers.Matching(qtype, clientIp, label)
+func (answers *Answers) Matching(qtype uint16, clientIp string, label string) (records []dns.RR, ok bool) {
+	clientSearches := answers.SearchSuffixes(clientIp)
+
+	// Client answers, client search
+	log.WithFields(log.Fields{"label": label, "client": clientIp}).Debug("Trying client answers, client search")
+	records, ok = answers.MatchingSearch(qtype, clientIp, label, clientSearches)
+	if ok {
+		return
+	}
+
+	// Default answers, client search
+	log.WithFields(log.Fields{"label": label, "client": clientIp}).Debug("Trying default answers, client search")
+	records, ok = answers.MatchingSearch(qtype, DEFAULT_KEY, label, clientSearches)
+	if ok {
+		return
+	}
+
+	// Default answers, default search
+	log.WithFields(log.Fields{"label": label, "client": clientIp}).Debug("Trying default answers, default search")
+	defaultSearches := answers.SearchSuffixes(DEFAULT_KEY)
+	records, ok = answers.MatchingSearch(qtype, DEFAULT_KEY, label, defaultSearches)
+	if ok {
+		return
+	}
+
+	return nil, false
+}
+
+func (answers *Answers) MatchingSearch(qtype uint16, clientIp string, label string, searches []string) (records []dns.RR, ok bool) {
+	records, ok = answers.MatchingExact(qtype, clientIp, label)
 	if ok {
 		log.WithFields(log.Fields{"fqdn": label, "client": clientIp}).Debug("Matched exact FQDN")
 		return
@@ -136,8 +160,9 @@ func (answers *Answers) MatchingAny(qtype uint16, clientIp string, label string,
 		if searches != nil && len(searches) > 0 {
 			for _, suffix := range searches {
 				newFqdn := base + "." + strings.TrimRight(suffix, ".") + "."
+				log.WithFields(log.Fields{"fqdn": newFqdn, "client": clientIp}).Debug("Trying alternate suffix")
 
-				records, ok = answers.Matching(qtype, clientIp, newFqdn)
+				records, ok = answers.MatchingExact(qtype, clientIp, newFqdn)
 				if ok {
 					log.WithFields(log.Fields{"fqdn": newFqdn, "client": clientIp}).Debug("Matched alternate suffix")
 					return
@@ -149,12 +174,12 @@ func (answers *Answers) MatchingAny(qtype uint16, clientIp string, label string,
 	return nil, false
 }
 
-func (answers *Answers) Matching(qtype uint16, clientIp string, fqdn string) (records []dns.RR, ok bool) {
+func (answers *Answers) MatchingExact(qtype uint16, clientIp string, fqdn string) (records []dns.RR, ok bool) {
 	client, ok := (*answers)[clientIp]
 	if ok {
 		switch qtype {
 		case dns.TypeA:
-			log.WithFields(log.Fields{"qtype": "A", "client": clientIp, "fqdn": fqdn}).Debug("Searching for A")
+			//log.WithFields(log.Fields{"qtype": "A", "client": clientIp, "fqdn": fqdn}).Debug("Searching for A")
 			res, ok := client.A[fqdn]
 			if ok && len(res.Answer) > 0 {
 				ttl := uint32(*defaultTtl)
@@ -173,7 +198,7 @@ func (answers *Answers) Matching(qtype uint16, clientIp string, fqdn string) (re
 			}
 
 		case dns.TypeCNAME:
-			log.WithFields(log.Fields{"qtype": "CNAME", "client": clientIp, "fqdn": fqdn}).Debug("Searching for CNAME")
+			//log.WithFields(log.Fields{"qtype": "CNAME", "client": clientIp, "fqdn": fqdn}).Debug("Searching for CNAME")
 			res, ok := client.Cname[fqdn]
 			ttl := uint32(*defaultTtl)
 			if res.Ttl != nil {
@@ -187,7 +212,7 @@ func (answers *Answers) Matching(qtype uint16, clientIp string, fqdn string) (re
 			}
 
 		case dns.TypePTR:
-			log.WithFields(log.Fields{"qtype": "PTR", "client": clientIp, "fqdn": fqdn}).Debug("Searching for PTR")
+			//log.WithFields(log.Fields{"qtype": "PTR", "client": clientIp, "fqdn": fqdn}).Debug("Searching for PTR")
 			res, ok := client.Ptr[fqdn]
 			ttl := uint32(*defaultTtl)
 			if res.Ttl != nil {
@@ -201,7 +226,7 @@ func (answers *Answers) Matching(qtype uint16, clientIp string, fqdn string) (re
 			}
 
 		case dns.TypeTXT:
-			log.WithFields(log.Fields{"qtype": "TXT", "client": clientIp, "fqdn": fqdn}).Debug("Searching for TXT")
+			//log.WithFields(log.Fields{"qtype": "TXT", "client": clientIp, "fqdn": fqdn}).Debug("Searching for TXT")
 			res, ok := client.Txt[fqdn]
 			ttl := uint32(*defaultTtl)
 			if res.Ttl != nil {

--- a/main.go
+++ b/main.go
@@ -144,9 +144,6 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	// Extra suffixes to search
-	searches := answers.SearchSuffixes(clientIp)
-
 	proto := "UDP"
 	if isTcp(w) {
 		proto = "TCP"
@@ -156,7 +153,7 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 
 	// A records may return CNAME answer(s) plus A answer(s)
 	if question.Qtype == dns.TypeA {
-		found, ok := answers.Addresses(clientIp, fqdn, nil, 1, searches)
+		found, ok := answers.Addresses(clientIp, fqdn, nil, 1)
 		if ok && len(found) > 0 {
 			log.WithFields(log.Fields{"client": clientIp, "type": rrString, "question": fqdn, "answers": len(found)}).Debug("Answered locally")
 			m.Answer = found
@@ -168,7 +165,7 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 		keys := []string{clientIp, DEFAULT_KEY}
 		for _, key := range keys {
 			// Client-specific answers
-			found, ok := answers.MatchingAny(question.Qtype, key, fqdn, searches)
+			found, ok := answers.Matching(question.Qtype, key, fqdn)
 			if ok {
 				log.WithFields(log.Fields{"client": key, "type": rrString, "question": fqdn, "answers": len(found)}).Debug("Answered from config for ", key)
 				m.Answer = found


### PR DESCRIPTION
Changes the search path behavior to try 3 separate sets of data:
  - Client IP answers + Client IP searches
  - Default answers + Client IP searches
  - Default answers + Default searches