### PR TITLE
Only program DNS with records from the same environments

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -161,6 +161,8 @@ func (c *ConfigGenerator) GetRecords() (map[string]RecordA, map[string]RecordCna
 		return nil, nil, nil, nil, nil, nil, err
 	}
 
+	selfEnvironmentUUID := host.EnvironmentUUID
+
 	uuidToPrimaryIp := make(map[string]string)
 	for _, c := range containers {
 		if c.PrimaryIp == "" {
@@ -171,6 +173,10 @@ func (c *ConfigGenerator) GetRecords() (map[string]RecordA, map[string]RecordCna
 
 	// get service records
 	for _, svc := range services {
+		// only fetch services from the same environment
+		if svc.EnvironmentUUID != selfEnvironmentUUID {
+			continue
+		}
 		svcNameToSvc[fmt.Sprintf("%s/%s", svc.StackName, svc.Name)] = svc
 		records, err := c.getServiceEndpoints(&svc, uuidToPrimaryIp)
 		if err != nil {
@@ -237,6 +243,10 @@ func (c *ConfigGenerator) GetRecords() (map[string]RecordA, map[string]RecordCna
 		}
 
 		if primaryIP == "" {
+			continue
+		}
+
+		if c.EnvironmentUUID != selfEnvironmentUUID {
 			continue
 		}
 

--- a/trash.yml
+++ b/trash.yml
@@ -15,7 +15,7 @@ import:
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 
 - package: github.com/rancher/go-rancher-metadata
-  version: ecd3b6d83ea92fba9837671e1b61a5efad7d5699
+  version: 4c6aeec78cf34419855c88e47066f816b9361569
 
 - package: gopkg.in/yaml.v2
   version: ca8f6aacaa4072fe5d27388b07162941cd750c65

--- a/vendor/github.com/rancher/go-rancher-metadata/metadata/types.go
+++ b/vendor/github.com/rancher/go-rancher-metadata/metadata/types.go
@@ -38,6 +38,7 @@ type Service struct {
 	HealthCheck        HealthCheck            `json:"health_check"`
 	PrimaryServiceName string                 `json:"primary_service_name"`
 	LBConfig           LBConfig               `json:"lb_config"`
+	EnvironmentUUID    string                 `json:"environment_uuid"`
 }
 
 type Container struct {
@@ -47,6 +48,7 @@ type Container struct {
 	Ips                      []string          `json:"ips"`
 	Ports                    []string          `json:"ports"`
 	ServiceName              string            `json:"service_name"`
+	ServiceIndex             string            `json:"service_index"`
 	StackName                string            `json:"stack_name"`
 	Labels                   map[string]string `json:"labels"`
 	CreateIndex              int               `json:"create_index"`
@@ -64,6 +66,8 @@ type Container struct {
 	NetworkFromContainerUUID string            `json:"network_from_container_uuid"`
 	NetworkUUID              string            `json:"network_uuid"`
 	Links                    map[string]string `json:"links"`
+	System                   bool              `json:"system"`
+	EnvironmentUUID          string            `json:"environment_uuid"`
 }
 
 type Network struct {
@@ -75,15 +79,16 @@ type Network struct {
 }
 
 type Host struct {
-	Name           string            `json:"name"`
-	AgentIP        string            `json:"agent_ip"`
-	HostId         int               `json:"host_id"`
-	Labels         map[string]string `json:"labels"`
-	UUID           string            `json:"uuid"`
-	Hostname       string            `json:"hostname"`
-	Memory         int64             `json:"memory"`
-	MilliCPU       int64             `json:"milli_cpu"`
-	LocalStorageMb int64             `json:"local_storage_mb"`
+	Name            string            `json:"name"`
+	AgentIP         string            `json:"agent_ip"`
+	HostId          int               `json:"host_id"`
+	Labels          map[string]string `json:"labels"`
+	UUID            string            `json:"uuid"`
+	Hostname        string            `json:"hostname"`
+	Memory          int64             `json:"memory"`
+	MilliCPU        int64             `json:"milli_cpu"`
+	LocalStorageMb  int64             `json:"local_storage_mb"`
+	EnvironmentUUID string            `json:"environment_uuid"`
 }
 
 type PortRule struct {


### PR DESCRIPTION
@ibuildthecloud with cross environment metadata, DNS should only generate records for the same environment. In the future we can add search domains with environmentUUID + rancherUUID to support cross environment/cross rancher resolution.