### PR TITLE
fix judge resolve dns error

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,7 +317,7 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 
 	// Phone a friend - Forward original query
 	msg, err := ResolveTryAll(req, answers.Recursers(clientIp))
-	if err == nil {
+	if err == nil && msg != nil {
 		msg.Compress = true
 		msg.Id = req.Id
 

--- a/resolve.go
+++ b/resolve.go
@@ -10,7 +10,7 @@ func ResolveTryAll(req *dns.Msg, resolvers []string) (resp *dns.Msg, err error) 
 	for _, resolver := range resolvers {
 		log.WithFields(log.Fields{"fqdn": req.Question[0].Name, "resolver": resolver}).Debug("Recursing")
 		resp, err = Resolve(req, resolver)
-		if err == nil {
+		if err == nil && resp != nil {
 			break
 		}
 	}


### PR DESCRIPTION
when resolvers is empty, the function ResolveTryAll will return that resp is nil and error is nil. the code in main.go:321 will cause panic

1/12/2017 5:00:49 PM[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x40e3dd]
1/12/2017 5:00:49 PM
1/12/2017 5:00:49 PMgoroutine 22 [running]:
1/12/2017 5:00:49 PMpanic(0x7d7620, 0xc420016060)
1/12/2017 5:00:49 PM  /usr/local/go/src/runtime/panic.go:500 +0x1a1
1/12/2017 5:00:49 PMmain.route(0xbd8960, 0xc420112770, 0xc420108480)
1/12/2017 5:00:49 PM  /go/src/github.com/rancher/rancher-dns/main.go:321 +0x90d
1/12/2017 5:00:49 PMgithub.com/rancher/rancher-dns/vendor/github.com/miekg/dns.HandlerFunc.ServeDNS(0x864580, 0xbd8960, 0xc420112770, 0xc420108480)
1/12/2017 5:00:49 PM  /go/src/github.com/rancher/rancher-dns/vendor/github.com/miekg/dns/server.go:82 +0x44
1/12/2017 5:00:49 PMgithub.com/rancher/rancher-dns/vendor/github.com/miekg/dns.(*ServeMux).ServeDNS(0xc420016910, 0xbd8960, 0xc420112770, 0xc420108480)
1/12/2017 5:00:49 PM  /go/src/github.com/rancher/rancher-dns/vendor/github.com/miekg/dns/server.go:186 +0x61
1/12/2017 5:00:49 PMgithub.com/rancher/rancher-dns/vendor/github.com/miekg/dns.(*Server).serve(0xc420128000, 0xbd4120, 0xc4208273b0, 0xbd1620, 0xc420016910, 0xc4207c8800, 0x3f, 0x200, 0xc420118028, 0xc42054f3c0, ...)
1/12/2017 5:00:49 PM  /go/src/github.com/rancher/rancher-dns/vendor/github.com/miekg/dns/server.go:535 +0x4e6
1/12/2017 5:00:49 PMcreated by github.com/rancher/rancher-dns/vendor/github.com/miekg/dns.(*Server).serveUDP
1/12/2017 5:00:49 PM  /go/src/github.com/rancher/rancher-dns/vendor/github.com/miekg/dns/server.go:489 +0x2c8
1/12/2017 5:00:51 PMtime="2017-01-12T09:00:51Z" level=info msg="Starting rancher-dns v0.13.0"
1/12/2017 5:00:51 PMtime="2017-01-12T09:00:51Z" level=info msg="Loaded answers"
1/12/2017 5:00:52 PMtime="2017-01-12T09:00:52Z" level=info msg="Listening for Reload on 127.0.0.1:8113"
1/12/2017 5:00:52 PMtime="2017-01-12T09:00:52Z" level=info msg="Listening on :53"