### PR TITLE
Handle SERVFAIL response from resolver

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
 	"strings"
-	"errors"
 )
 
 func ResolveTryAll(req *dns.Msg, resolvers []string) (resp *dns.Msg, err error) {

--- a/resolve.go
+++ b/resolve.go
@@ -10,7 +10,9 @@ func ResolveTryAll(req *dns.Msg, resolvers []string) (resp *dns.Msg, err error) 
 	for _, resolver := range resolvers {
 		log.WithFields(log.Fields{"fqdn": req.Question[0].Name, "resolver": resolver}).Debug("Recursing")
 		resp, err = Resolve(req, resolver)
-		if err == nil {
+
+		// Do not consider SERVFAIL as as a successful response. Move onto the next resolver.
+		if err == nil && resp.Rcode != dns.RcodeServerFailure {
 			break
 		}
 	}


### PR DESCRIPTION
If a resolver responds with a SERVFAIL error, the underlying client does not consider this an error. This results in that failure being cached for the TTL duration of rancher-dns. 