### PR TITLE
fix to honor upstream TTL 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,7 +11,7 @@ RUN apt-get update && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.7.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/cache.go
+++ b/cache.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"time"
+
 	"github.com/miekg/dns"
-	"github.com/skynetservices/skydns/cache"
+	"github.com/rancher/rancher-dns/cache"
 )
 
 func getClientCache(clientIp string) *cache.Cache {
@@ -27,26 +29,41 @@ func addClientCache(clientIp string) {
 	clientSpecificCachesMutex.Unlock()
 }
 
-func globalCacheHit(req *dns.Msg) *dns.Msg {
+func globalCacheHit(req *dns.Msg) (*dns.Msg, time.Time) {
 	return globalCache.Hit(req.Question[0], false, false, req.MsgHdr.Id)
 }
 
-func clientSpecificCacheHit(clientIp string, req *dns.Msg) *dns.Msg {
+func clientSpecificCacheHit(clientIp string, req *dns.Msg) (*dns.Msg, time.Time) {
 	addClientCache(clientIp)
 	clientCache := getClientCache(clientIp)
 	return clientCache.Hit(req.Question[0], false, false, req.MsgHdr.Id)
 }
 
-func addToGlobalCache(req, msg *dns.Msg) {
+func addToCache(req, msg *dns.Msg, clientIp ...string) {
+	var currCache *cache.Cache
+	if len(clientIp) == 0 {
+		currCache = globalCache
+	} else {
+		addClientCache(clientIp[0])
+		currCache = getClientCache(clientIp[0])
+	}
+	ttl := currCache.GetTTL()
+	if len(msg.Answer) > 0 {
+		var requestTtl = time.Duration(msg.Answer[0].Header().Ttl) * time.Second
+		if requestTtl < ttl {
+			ttl = requestTtl
+		}
+	}
 	key := cache.Key(req.Question[0], false, false)
-	globalCache.InsertMessage(key, msg)
+	currCache.InsertMessage(key, msg, ttl)
+}
+
+func addToGlobalCache(req, msg *dns.Msg) {
+	addToCache(req, msg)
 }
 
 func addToClientSpecificCache(clientIp string, req, msg *dns.Msg) {
-	addClientCache(clientIp)
-	clientCache := getClientCache(clientIp)
-	key := cache.Key(req.Question[0], false, false)
-	clientCache.InsertMessage(key, msg)
+	addToCache(req, msg, clientIp)
 }
 
 func clearClientSpecificCaches() {

--- a/cache/AUTHORS
+++ b/cache/AUTHORS
@@ -1,0 +1,4 @@
+Erik St. Martin
+Brian Ketelsen
+Miek Gieben
+Michael Crosby

--- a/cache/CONTRIBUTORS
+++ b/cache/CONTRIBUTORS
@@ -1,0 +1,7 @@
+The following people have contributed to this project:
+
+Erik St. Martin <alakriti@gmail.com>
+Brian Ketelsen <bketelsen@gmail.com>
+Miek Gieben <miek@miek.nl>
+Sean Carey <sean@densone.com>
+Michael Crosby <michael@crosbymichael.com>

--- a/cache/LICENSE
+++ b/cache/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 The SkyDNS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,166 @@
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
+package cache
+
+// Cache that holds RRs and for DNSSEC an RRSIG.
+
+// TODO(miek): there is a lot of copying going on to copy myself out of data
+// races. This should be optimized.
+
+import (
+	"crypto/sha1"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Elem hold an answer and additional section that returned from the cache.
+// The signature is put in answer, extra is empty there. This wastes some memory.
+type elem struct {
+	expiration time.Time // time added + TTL, after this the elem is invalid
+	msg        *dns.Msg
+}
+
+// Cache is a cache that holds on the a number of RRs or DNS messages. The cache
+// eviction is randomized.
+type Cache struct {
+	sync.RWMutex
+
+	capacity int
+	m        map[string]*elem
+	ttl      time.Duration
+}
+
+// New returns a new cache with the capacity and the ttl specified.
+func New(capacity, ttl int) *Cache {
+	c := new(Cache)
+	c.m = make(map[string]*elem)
+	c.capacity = capacity
+	c.ttl = time.Duration(ttl) * time.Second
+	return c
+}
+
+func (c *Cache) Capacity() int { return c.capacity }
+
+func (c *Cache) Remove(s string) {
+	c.Lock()
+	delete(c.m, s)
+	c.Unlock()
+}
+
+// EvictRandom removes a random member a the cache.
+// Must be called under a write lock.
+func (c *Cache) EvictRandom() {
+	clen := len(c.m)
+	if clen < c.capacity {
+		return
+	}
+	i := c.capacity - clen
+	for k, _ := range c.m {
+		delete(c.m, k)
+		i--
+		if i == 0 {
+			break
+		}
+	}
+}
+
+// InsertMessage inserts a message in the Cache. We will cache it for ttl seconds, which
+// should be a small (60...300) integer.
+func (c *Cache) InsertMessage(s string, msg *dns.Msg) {
+	if c.capacity <= 0 {
+		return
+	}
+
+	c.Lock()
+	if _, ok := c.m[s]; !ok {
+		c.m[s] = &elem{time.Now().UTC().Add(c.ttl), msg.Copy()}
+
+	}
+	c.EvictRandom()
+	c.Unlock()
+}
+
+// InsertSignature inserts a signature, the expiration time is used as the cache ttl.
+func (c *Cache) InsertSignature(s string, sig *dns.RRSIG) {
+	if c.capacity <= 0 {
+		return
+	}
+	c.Lock()
+
+	if _, ok := c.m[s]; !ok {
+		m := ((int64(sig.Expiration) - time.Now().Unix()) / (1 << 31)) - 1
+		if m < 0 {
+			m = 0
+		}
+		t := time.Unix(int64(sig.Expiration)-(m*(1<<31)), 0).UTC()
+		c.m[s] = &elem{t, &dns.Msg{Answer: []dns.RR{dns.Copy(sig)}}}
+	}
+	c.EvictRandom()
+	c.Unlock()
+}
+
+// Search returns a dns.Msg, the expiration time and a boolean indicating if we found something
+// in the cache.
+func (c *Cache) Search(s string) (*dns.Msg, time.Time, bool) {
+	if c.capacity <= 0 {
+		return nil, time.Time{}, false
+	}
+	c.RLock()
+	if e, ok := c.m[s]; ok {
+		e1 := e.msg.Copy()
+		c.RUnlock()
+		return e1, e.expiration, true
+	}
+	c.RUnlock()
+	return nil, time.Time{}, false
+}
+
+// Key creates a hash key from a question section. It creates a different key
+// for requests with DNSSEC.
+func Key(q dns.Question, dnssec, tcp bool) string {
+	h := sha1.New()
+	i := append([]byte(q.Name), packUint16(q.Qtype)...)
+	if dnssec {
+		i = append(i, byte(255))
+	}
+	if tcp {
+		i = append(i, byte(254))
+	}
+	return string(h.Sum(i))
+}
+
+// Key uses the name, type and rdata, which is serialized and then hashed as the key for the lookup.
+func KeyRRset(rrs []dns.RR) string {
+	h := sha1.New()
+	i := []byte(rrs[0].Header().Name)
+	i = append(i, packUint16(rrs[0].Header().Rrtype)...)
+	for _, r := range rrs {
+		switch t := r.(type) { // we only do a few type, serialize these manually
+		case *dns.SOA:
+			// We only fiddle with the serial so store that.
+			i = append(i, packUint32(t.Serial)...)
+		case *dns.SRV:
+			i = append(i, packUint16(t.Priority)...)
+			i = append(i, packUint16(t.Weight)...)
+			i = append(i, packUint16(t.Weight)...)
+			i = append(i, []byte(t.Target)...)
+		case *dns.A:
+			i = append(i, []byte(t.A)...)
+		case *dns.AAAA:
+			i = append(i, []byte(t.AAAA)...)
+		case *dns.NSEC3:
+			i = append(i, []byte(t.NextDomain)...)
+			// Bitmap does not differentiate in SkyDNS.
+		case *dns.DNSKEY:
+		case *dns.NS:
+		case *dns.TXT:
+		}
+	}
+	return string(h.Sum(i))
+}
+
+func packUint16(i uint16) []byte { return []byte{byte(i >> 8), byte(i)} }
+func packUint32(i uint32) []byte { return []byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)} }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2014 The SkyDNS Authors. All rights reserved.
 // Use of this source code is governed by The MIT License (MIT) that can be
 // found in the LICENSE file.
 
@@ -69,14 +70,14 @@ func (c *Cache) EvictRandom() {
 
 // InsertMessage inserts a message in the Cache. We will cache it for ttl seconds, which
 // should be a small (60...300) integer.
-func (c *Cache) InsertMessage(s string, msg *dns.Msg) {
+func (c *Cache) InsertMessage(s string, msg *dns.Msg, ttl time.Duration) {
 	if c.capacity <= 0 {
 		return
 	}
 
 	c.Lock()
 	if _, ok := c.m[s]; !ok {
-		c.m[s] = &elem{time.Now().UTC().Add(c.ttl), msg.Copy()}
+		c.m[s] = &elem{time.Now().UTC().Add(ttl), msg.Copy()}
 
 	}
 	c.EvictRandom()
@@ -164,3 +165,5 @@ func KeyRRset(rrs []dns.RR) string {
 
 func packUint16(i uint16) []byte { return []byte{byte(i >> 8), byte(i)} }
 func packUint32(i uint32) []byte { return []byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i)} }
+
+func (c *Cache) GetTTL() time.Duration { return c.ttl }

--- a/cache/hit.go
+++ b/cache/hit.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2014 The SkyDNS Authors. All rights reserved.
+// Use of this source code is governed by The MIT License (MIT) that can be
+// found in the LICENSE file.
+
+package cache
+
+import (
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Hit returns a dns message from the cache. If the message's TTL is expired nil
+// is returned and the message is removed from the cache.
+func (c *Cache) Hit(question dns.Question, dnssec, tcp bool, msgid uint16) *dns.Msg {
+	key := Key(question, dnssec, tcp)
+	m1, exp, hit := c.Search(key)
+	if hit {
+		// Cache hit! \o/
+		if time.Since(exp) < 0 {
+			m1.Id = msgid
+			m1.Compress = true
+			// Even if something ended up with the TC bit *in* the cache, set it to off
+			m1.Truncated = false
+			return m1
+		}
+		// Expired! /o\
+		c.Remove(key)
+	}
+	return nil
+}

--- a/cache/hit.go
+++ b/cache/hit.go
@@ -12,7 +12,7 @@ import (
 
 // Hit returns a dns message from the cache. If the message's TTL is expired nil
 // is returned and the message is removed from the cache.
-func (c *Cache) Hit(question dns.Question, dnssec, tcp bool, msgid uint16) *dns.Msg {
+func (c *Cache) Hit(question dns.Question, dnssec, tcp bool, msgid uint16) (*dns.Msg, time.Time) {
 	key := Key(question, dnssec, tcp)
 	m1, exp, hit := c.Search(key)
 	if hit {
@@ -22,10 +22,10 @@ func (c *Cache) Hit(question dns.Question, dnssec, tcp bool, msgid uint16) *dns.
 			m1.Compress = true
 			// Even if something ended up with the TC bit *in* the cache, set it to off
 			m1.Truncated = false
-			return m1
+			return m1, exp
 		}
 		// Expired! /o\
 		c.Remove(key)
 	}
-	return nil
+	return nil, time.Now()
 }

--- a/main.go
+++ b/main.go
@@ -268,13 +268,6 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	if msg, exp := globalCacheHit(req); msg != nil {
-		update(msg, exp)
-		Respond(w, req, msg)
-		log.WithFields(log.Fields{"client": clientIp, "type": rrString, "question": fqdn}).Debug("Sent globally cached response")
-		return
-	}
-
 	// A records may return CNAME answer(s) plus A answer(s)
 	if question.Qtype == dns.TypeA {
 		found, ok := answers.Addresses(clientIp, fqdn, nil, 1)
@@ -311,6 +304,13 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 		}
 
 		log.Debug("No match found in config")
+	}
+
+	if msg, exp := globalCacheHit(req); msg != nil {
+		update(msg, exp)
+		Respond(w, req, msg)
+		log.WithFields(log.Fields{"client": clientIp, "type": rrString, "question": fqdn}).Debug("Sent globally cached response")
+		return
 	}
 
 	// If we are authoritative for a suffix the label has, there's no point trying the recursive DNS

--- a/test/integration/05-caching-dns.bats
+++ b/test/integration/05-caching-dns.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "TTL initializes to correct value in global cache" {
+  run resolve yahoo.com
+  log $output
+  [ $status -eq 0 ]
+  yahoottl=$(echo "$output" | grep -A1 "ANSWER SECTION" | grep "yahoo.com" | awk '{print $2}')
+  run resolve service-baz
+  log $output
+  [ $status -eq 0 ]
+  # cachettl=$(echo "$output" | sed -n -e 's/^.*ANSWER SECTION: service-baz. //p' | awk '{print $1}')
+  cachettl=$(echo "$output" | grep -A1 "ANSWER SECTION" | grep "service-baz" | awk '{print $2}')
+  echo "output = ${output}"
+  echo "cachettl = ${cachettl}"
+  echo "yahoottl = ${yahoottl}"
+  [[ "$yahoottl" -le "$cachettl" ]] || false
+}
+
+@test "TTL decreases as time passes for requests stored in client cache" {
+  run resolve service-baz
+  log $output
+  [ $status -eq 0 ]
+  old_ttl=$(echo "$output" | grep -A1 "ANSWER SECTION" | grep "service-baz" | awk '{print $2}')
+  for i in {1..3}; do
+      sleep 5
+      run resolve service-baz
+      log $output
+      [ $status -eq 0 ]
+      new_ttl=$(echo "$output" | grep -A1 "ANSWER SECTION" | grep "service-baz" | awk '{print $2}')
+      echo "old_ttl = ${old_ttl}"
+      echo "new_ttl = ${new_ttl}"
+      [[ "$new_ttl" -lt "$old_ttl" ]] || false
+      old_ttl=$new_ttl
+  done
+}
+
+@test "TTL decreases as time passes for requests stored in global cache" {
+  run resolve yahoo.com A
+  log $output
+  [ $status -eq 0 ]
+  old_ttl=$(echo "$output" | grep -A1 "ANSWER SECTION" | grep "yahoo.com" | awk '{print $2}')
+  # old_ttl=$(dig yahoo.com | sed -n -e 's/^.*ANSWER SECTION: yahoo.com. //p' | awk '{print $1}')
+  for i in {1..3}; do
+      sleep 5
+      run resolve yahoo.com A
+      log $output
+      [ $status -eq 0 ]
+      # new_ttl=$(dig yahoo.com | sed -n -e 's/^.*ANSWER SECTION: yahoo.com. //p' | awk '{print $1}')
+      new_ttl=$(echo "$output" | grep -A1 "ANSWER SECTION" | grep "yahoo.com" | awk '{print $2}')
+      [[ "$new_ttl" -lt "$old_ttl" ]] || false
+      old_ttl=$new_ttl
+  done
+}

--- a/trash.yml
+++ b/trash.yml
@@ -5,9 +5,6 @@ import:
 - package: github.com/miekg/dns
   version: 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 
-- package: github.com/skynetservices/skydns
-  version: f7b6fb74bcfab300b4e7e0e27b1fe6c0ed555f78
-
 - package: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 


### PR DESCRIPTION
[rancher/rancher#8805](https://github.com/rancher/rancher/issues/8805)
Currently, all requests are stored with default TTL. This is to allow requests to be stored with their own TTL (if it is less than cache's default TTL value). 

This fix also solves issue [rancher/rancher#8504](https://github.com/rancher/rancher/issues/8504), search locally first before hitting the global cache.  